### PR TITLE
Increase base upper bound up to <4.17

### DIFF
--- a/perfect-vector-shuffle.cabal
+++ b/perfect-vector-shuffle.cabal
@@ -77,7 +77,7 @@ Library
                     -fexpose-all-unfoldings
                     -fspecialise-aggressively
 
-  build-depends:    base        >= 4.9      && < 4.16
+  build-depends:    base        >= 4.9      && < 4.17
                   , MonadRandom >= 0.5.1.1  && < 0.6
                   , primitive   >= 0.6.4    && < 0.8
                   , random      >= 1.1      && < 1.3

--- a/perfect-vector-shuffle.cabal
+++ b/perfect-vector-shuffle.cabal
@@ -77,7 +77,7 @@ Library
                     -fexpose-all-unfoldings
                     -fspecialise-aggressively
 
-  build-depends:    base        >= 4.9      && < 4.15
+  build-depends:    base        >= 4.9      && < 4.16
                   , MonadRandom >= 0.5.1.1  && < 0.6
                   , primitive   >= 0.6.4    && < 0.8
                   , random      >= 1.1      && < 1.3


### PR DESCRIPTION
I checked and it builds against 4.15 and 4.16 without changes. The tests still pass too.